### PR TITLE
Fix #1: Add optional configuration for converting string inputs to integer or float

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,9 @@
 /**
  * Takes a user input from terminal and returns a string
  * @param {string} [prompt=]
- * @returns {Promise<String>}
+ * @param {Object} [options={}] - The options for parsing input. Possible properties:
+ *   - { boolean } int: When true, parses the input as an integer.
+ *   - { boolean } float: When true, parses the input as a float.
+ * @returns {Promise<String|Number>}
  */
-export function input(prompt?: string): Promise<string>;
+export function input(prompt?: string, options?: { int?: boolean, float?: boolean }): Promise<string | number>;

--- a/index.js
+++ b/index.js
@@ -4,12 +4,32 @@ import readline from "node:readline/promises";
 /**
  * Takes a user input from terminal and returns a string
  * @param {string} [prompt=]
- * @returns {Promise<String>}
+ * @param {Object} [options={}] - The options for parsing input: { int: true } or { float: true }
+ * @returns {Promise<String|Number>}
  */
 export async function input(prompt = "") {
 	const rl = readline.createInterface({ input: stdin, output });
 
 	const result = await rl.question(prompt);
 	rl.close();
+
+	const parsed_int = parseInt(result, 10)
+	const parsed_float = parseFloat(result)
+
+	if (options.int) {
+		if (isNaN(parsed_int)) {
+			throw new Error("input is not a valid integer");
+		}
+		return parsed_int;
+	}
+
+	if (options.float) {
+		if (isNaN(parsed_float)) {
+			throw new Error("input is not a valid float");
+		}
+		return parsed_float;
+	}
+
+
 	return result;
 }

--- a/index.js
+++ b/index.js
@@ -7,16 +7,14 @@ import readline from "node:readline/promises";
  * @param {Object} [options={}] - The options for parsing input: { int: true } or { float: true }
  * @returns {Promise<String|Number>}
  */
-export async function input(prompt = "") {
+export async function input(prompt = "", options = {}) {
 	const rl = readline.createInterface({ input: stdin, output });
 
 	const result = await rl.question(prompt);
 	rl.close();
 
-	const parsed_int = parseInt(result, 10)
-	const parsed_float = parseFloat(result)
-
 	if (options.int) {
+        const parsed_int = parseInt(result, 10)
 		if (isNaN(parsed_int)) {
 			throw new Error("input is not a valid integer");
 		}
@@ -24,6 +22,7 @@ export async function input(prompt = "") {
 	}
 
 	if (options.float) {
+        const parsed_float = parseFloat(result)
 		if (isNaN(parsed_float)) {
 			throw new Error("input is not a valid float");
 		}


### PR DESCRIPTION
This pull request introduces a new feature to the `input` function, allowing it to optionally convert string inputs to integers or floats based on the provided configuration.

**Changes:**

- **Added Optional Configuration:**
  - **`int` Option:** When set to `true`, the input will be parsed as an integer.
  - **`float` Option:** When set to `true`, the input will be parsed as a float.
- **Updated Function Signature:**
  - The `input` function now accepts an `options` object with `int` and `float` properties.
  - The function returns a `Promise<string | number>` based on the parsed value.

**Usage Examples:**

1. **Prompt for a String:**
   ```typescript
   const name: string = await input("Enter your name: ");
   ```

2. **Prompt for an Integer:**
   ```typescript
   const age: number = await input("Enter your age: ", { int: true });
   ```

3. **Prompt for a Float:**
   ```typescript
   const height: number = await input("Enter your height (in meters): ", { float: true });
   ```

**Related Issues:**
- Fixes issue #1.

**Notes:**
- If both `int` and `float` options are provided, `int` will take precedence.
- If the input cannot be parsed into the specified type, an error will be thrown.

Please review the changes and let me know if any adjustments are needed.
